### PR TITLE
fix: improve grep for remove branches

### DIFF
--- a/bin/create-release-branch
+++ b/bin/create-release-branch
@@ -77,7 +77,7 @@ hasPackageJson () {
 }
 
 hasMaintenanceBranch () {
-  if ! [ -z "$(git branch -a | grep -w $RELEASE_BRANCH_NAME)" ]; then
+  if ! [ -z "$(git branch -a | grep /$RELEASE_BRANCH_NAME$)" ]; then
     redLog "ERR: A branch named $RELEASE_BRANCH_NAME already exists locally or remotely."
     exit 1
   fi

--- a/bin/finish-release
+++ b/bin/finish-release
@@ -39,7 +39,7 @@ if [ "x$localBranchExists" != "x" ]; then
 fi
 
 # Stop if there is no remote release branch
-remoteBranchExists=$(git branch -r | { grep -w "release-$releaseVersion" || true; })
+remoteBranchExists=$(git branch -r | { grep /release-$releaseVersion$ || true; })
 if [ "x$remoteBranchExists" = "x" ]; then
   yellowLog "ERR: There is no remote branch release-$releaseVersion.
     Please execute 'init-release' first"

--- a/bin/init-release
+++ b/bin/init-release
@@ -35,7 +35,7 @@ fi
 
 
 # Does the branch to create already exist?
-if [ $(git branch -a | grep -w "release-$releaseVersion") ]; then
+if [ $(git branch -a | grep /release-$releaseVersion$) ]; then
    yellowLog "ERR: Branch release-$releaseVersion already exists."
    exit 1
 fi

--- a/bin/push-feat-commit
+++ b/bin/push-feat-commit
@@ -26,7 +26,7 @@ fi
 
 
 # Does the branch to create already exist?
-if [ $(git branch -a | grep -w "bump-$version") ]; then
+if [ $(git branch -a | grep /bump-$version$) ]; then
   yellowLog "ERR: Branch bump-$version already exists."
   exit 1
 fi


### PR DESCRIPTION
## Motivation

We use `grep` a few times to find out if we can continue with creating or finishing release branches. But the grep rules were inaccurate.

## Changelog

```bash
# before
❯ grep -w release-11.0.2 <<< 'origin/greenkeeper/semantic-release-11.0.2'
origin/greenkeeper/semantic-release-11.0.2

❯ grep -w release-11.0.2 <<< 'origin/greenkeeper/release-11.0.2'
origin/greenkeeper/semantic-release-11.0.2

# now
❯ grep /release-11.0.2$ <<< 'origin/greenkeeper/semantic-release-11.0.2'

❯ grep /release-11.0.2$ <<< 'origin/greenkeeper/release-11.0.2'
origin/greenkeeper/release-11.0.2
```