### PR TITLE
Fix execution of template string with shell.exec

### DIFF
--- a/lib/modules/exec.js
+++ b/lib/modules/exec.js
@@ -1,11 +1,11 @@
 module.exports = function (dep) {
   const { shell, console, colors } = dep
   return function (command, dryRun = false) {
-    console.log(colors.yellow(`  ${command}`))
+    const cmd = command.replace(/(?:\\[rn]|[\r\n]+)+/g, '')
+    console.log(colors.yellow(`  ${cmd}`))
     if (!dryRun) {
-      const result = shell.exec(command)
-      result.stdout = result.stdout.replace(/\n$/, '')
-      result.stdout = result.stdout.replace(/\n$/, '')
+      const result = shell.exec(cmd)
+      result.stdout = result.stdout.replace(/(?:\\[rn]|[\r\n]+)+/g, '')
       return result
     }
   }


### PR DESCRIPTION
## Description
Template strings are now executed properly with `shell.exec`